### PR TITLE
DT-28: Check and test for maximum lengths on name fields for user creation.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserService.java
@@ -39,10 +39,13 @@ public class AuthUserService {
     private final AuthUserGroupService authUserGroupService;
     private final String initialPasswordTemplateId;
 
-    // Sizes limited for fixed column sizes in repository
-    private static int MAX_LENGTH_USERNAME = 30;
-    private static int MAX_LENGTH_FIRST_NAME = 50;
-    private static int MAX_LENGTH_LAST_NAME = 50;
+    // Data item field size validation checks
+    private static final int MAX_LENGTH_USERNAME = 30;
+    private static final int MAX_LENGTH_FIRST_NAME = 50;
+    private static final int MAX_LENGTH_LAST_NAME = 50;
+    private static final int MIN_LENGTH_USERNAME = 6;
+    private static final int MIN_LENGTH_FIRST_NAME = 2;
+    private static final int MIN_LENGTH_LAST_NAME = 2;
 
     public AuthUserService(final UserTokenRepository userTokenRepository,
                            final UserEmailRepository userEmailRepository,
@@ -161,17 +164,26 @@ public class AuthUserService {
     private void validate(final String username, final String email, final String firstName, final String lastName)
             throws CreateUserException, VerifyEmailException {
 
-        if (StringUtils.length(username) < 6 || StringUtils.length(username) > MAX_LENGTH_USERNAME) {
+        if (StringUtils.length(username) < MIN_LENGTH_USERNAME) {
             throw new CreateUserException("username", "length");
+        }
+        if (StringUtils.length(username) > MAX_LENGTH_USERNAME) {
+            throw new CreateUserException("username", "maxlength");
         }
         if (!username.matches("^[A-Z0-9_]*$")) {
             throw new CreateUserException("username", "format");
         }
-        if (StringUtils.length(firstName) < 2 || StringUtils.length(firstName) > MAX_LENGTH_FIRST_NAME) {
+        if (StringUtils.length(firstName) < MIN_LENGTH_FIRST_NAME) {
             throw new CreateUserException("firstName", "length");
         }
-        if (StringUtils.length(lastName) < 2 || StringUtils.length(lastName) > MAX_LENGTH_LAST_NAME) {
+        if (StringUtils.length(firstName) > MAX_LENGTH_FIRST_NAME) {
+            throw new CreateUserException("firstName", "maxlength");
+        }
+        if (StringUtils.length(lastName) < MIN_LENGTH_LAST_NAME) {
             throw new CreateUserException("lastName", "length");
+        }
+        if (StringUtils.length(lastName) > MAX_LENGTH_LAST_NAME) {
+            throw new CreateUserException("lastName", "maxlength");
         }
 
         verifyEmailService.validateEmailAddress(email);

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserService.java
@@ -39,6 +39,11 @@ public class AuthUserService {
     private final AuthUserGroupService authUserGroupService;
     private final String initialPasswordTemplateId;
 
+    // Sizes limited for fixed column sizes in repository
+    private static int MAX_LENGTH_USERNAME = 30;
+    private static int MAX_LENGTH_FIRST_NAME = 50;
+    private static int MAX_LENGTH_LAST_NAME = 50;
+
     public AuthUserService(final UserTokenRepository userTokenRepository,
                            final UserEmailRepository userEmailRepository,
                            final NotificationClientApi notificationClient,
@@ -156,16 +161,16 @@ public class AuthUserService {
     private void validate(final String username, final String email, final String firstName, final String lastName)
             throws CreateUserException, VerifyEmailException {
 
-        if (StringUtils.length(username) < 6) {
+        if (StringUtils.length(username) < 6 || StringUtils.length(username) > MAX_LENGTH_USERNAME) {
             throw new CreateUserException("username", "length");
         }
         if (!username.matches("^[A-Z0-9_]*$")) {
             throw new CreateUserException("username", "format");
         }
-        if (StringUtils.length(firstName) < 2) {
+        if (StringUtils.length(firstName) < 2 || StringUtils.length(firstName) > MAX_LENGTH_FIRST_NAME) {
             throw new CreateUserException("firstName", "length");
         }
-        if (StringUtils.length(lastName) < 2) {
+        if (StringUtils.length(lastName) < 2 || StringUtils.length(lastName) > MAX_LENGTH_LAST_NAME) {
             throw new CreateUserException("lastName", "length");
         }
 

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserServiceTest.java
@@ -75,8 +75,20 @@ public class AuthUserServiceTest {
     }
 
     @Test
+    public void createUser_firstNameMaxLength() {
+        assertThatThrownBy(() -> authUserService.createUser("userme", "email", "ThisFirstNameIsMoreThanFiftyCharactersInLengthAndInvalid", "last", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
+                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field firstName with reason: length");
+    }
+
+    @Test
     public void createUser_lastNameLength() {
         assertThatThrownBy(() -> authUserService.createUser("userme", "email", "se", "x", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
+                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field lastName with reason: length");
+    }
+
+    @Test
+    public void createUser_lastNameMaxLength() {
+        assertThatThrownBy(() -> authUserService.createUser("userme", "email", "se", "ThisLastNameIsMoreThanFiftyCharactersInLengthAndInvalid", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
                 isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field lastName with reason: length");
     }
 

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserServiceTest.java
@@ -63,6 +63,12 @@ public class AuthUserServiceTest {
     }
 
     @Test
+    public void createUser_usernameMaxLength() {
+        assertThatThrownBy(() -> authUserService.createUser("ThisIsLongerThanTheAllowedUsernameLength", "email", "first", "last", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
+                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field username with reason: maxlength");
+    }
+
+    @Test
     public void createUser_usernameFormat() {
         assertThatThrownBy(() -> authUserService.createUser("user-name", "email", "first", "last", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
                 isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field username with reason: format");
@@ -77,7 +83,7 @@ public class AuthUserServiceTest {
     @Test
     public void createUser_firstNameMaxLength() {
         assertThatThrownBy(() -> authUserService.createUser("userme", "email", "ThisFirstNameIsMoreThanFiftyCharactersInLengthAndInvalid", "last", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
-                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field firstName with reason: length");
+                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field firstName with reason: maxlength");
     }
 
     @Test
@@ -89,7 +95,7 @@ public class AuthUserServiceTest {
     @Test
     public void createUser_lastNameMaxLength() {
         assertThatThrownBy(() -> authUserService.createUser("userme", "email", "se", "ThisLastNameIsMoreThanFiftyCharactersInLengthAndInvalid", null, "url", "bob", GRANTED_AUTHORITY_SUPER_USER)).
-                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field lastName with reason: length");
+                isInstanceOf(CreateUserException.class).hasMessage("Create user failed for field lastName with reason: maxlength");
     }
 
     @Test


### PR DESCRIPTION
This change produces an error from the API when names longer than the maximum are submitted in a create user request. Raised as a bug via Licences testing.