### PR TITLE
DT-421 Delius unavailble warning

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfiguration.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfiguration.java
@@ -138,6 +138,11 @@ public class AuthenticationManagerConfiguration extends WebSecurityConfigurerAda
         return super.authenticationManagerBean();
     }
 
+    /**
+     * An assumption is made in DeliusUserService that the delius auth provider is checked last and if Delius is down
+     * then we do not check with any further providers.
+     *
+     */
     @Override
     protected void configure(final AuthenticationManagerBuilder auth) {
         auth.authenticationProvider(authAuthenticationProvider);

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/delius/service/DeliusUserService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/delius/service/DeliusUserService.kt
@@ -9,11 +9,13 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
 import uk.gov.justice.digital.hmpps.oauth2server.config.DeliusRoleMappings
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.DeliusUserPersonDetails
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.UserDetails
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.UserRole
+import uk.gov.justice.digital.hmpps.oauth2server.security.DeliusAuthenticationServiceException
 import java.util.*
 
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
@@ -43,6 +45,8 @@ open class DeliusUserService(@Qualifier("deliusApiRestTemplate") private val res
         log.warn("Unable to get delius user details for user {} due to {}", username, e.statusCode, e)
       }
       Optional.empty()
+    } catch(e: ResourceAccessException) {
+      throw DeliusAuthenticationServiceException()
     } catch (e: Exception) {
       log.warn("Unable to get delius user details for user {}", username, e)
       Optional.empty()

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/DeliusAuthenticationServiceException.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/DeliusAuthenticationServiceException.java
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.oauth2server.security;
+
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+
+public class DeliusAuthenticationServiceException extends InternalAuthenticationServiceException {
+    public DeliusAuthenticationServiceException() {
+        super("Delius is currently not responding");
+    }
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserStateAuthenticationFailureHandler.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserStateAuthenticationFailureHandler.java
@@ -43,6 +43,8 @@ public class UserStateAuthenticationFailureHandler extends SimpleUrlAuthenticati
             if (StringUtils.isBlank(request.getParameter("password"))) {
                 builder.add("missingpass");
             }
+        } else if (exception instanceof DeliusAuthenticationServiceException) {
+            builder.add("invalid").add("deliusdown");
         } else {
             builder.add("invalid");
         }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,6 +4,7 @@ login.expired=Your session has expired.  Enter your username and existing passwo
 login.locked=Your account is locked. If you have verified your email address then you can use 'I have forgotten my password' below.
 login.changepassword=Your password has been changed. Enter your username and new password to sign in.
 login.invalid=Enter a valid username and password. You will be locked out if you enter the wrong details {0} times.
+login.deliusdown=Delius is experiencing issues. Please try later if you are attempting to login using your Delius credentials.
 
 changepassword.invalid=Your password is incorrect. You will be locked out if you enter the wrong details {0} times.
 changepassword.missing=Enter your current password

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -46,6 +46,7 @@
           <a th:case="'invalid'" href="#username"
              th:text="#{login.invalid(${@environment.getProperty('application.authentication.lockout-count')})}">
             Invalid message</a>
+          <a th:case="'deliusdown'" href="#username" th:text="#{login.deliusdown}">Delius unavailable message</a>
           <a th:case="*" href="#username" th:text="#{${'login.' + error}}">Username message</a>
         </li>
       </ul>

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/DeliusDownLoginSepcification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/DeliusDownLoginSepcification.groovy
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.oauth2server.integration.specs
+
+import uk.gov.justice.digital.hmpps.oauth2server.integration.specs.pages.HomePage
+import uk.gov.justice.digital.hmpps.oauth2server.integration.specs.pages.LoginErrorPage
+import uk.gov.justice.digital.hmpps.oauth2server.integration.specs.pages.LoginPage
+
+import static uk.gov.justice.digital.hmpps.oauth2server.integration.specs.model.UserAccount.AUTH_USER
+import static uk.gov.justice.digital.hmpps.oauth2server.integration.specs.model.UserAccount.DELIUS_USER
+import static uk.gov.justice.digital.hmpps.oauth2server.integration.specs.model.UserAccount.ITAG_USER
+
+class DeliusDownLoginSepcification extends BrowserReportingSpec {
+
+    def "Delius unavailable shows in error"() {
+        given: 'I am on the Login page'
+        to LoginPage
+
+        when: "I login using valid Delius credentials"
+        loginAs DELIUS_USER, 'password'
+
+        then: 'My credentials are rejected and I am still on the Login page'
+        at LoginErrorPage
+        errorText == "Enter a valid username and password. You will be locked out if you enter the wrong details 3 times." +
+                "\nDelius is experiencing issues. Please try later if you are attempting to login using your Delius credentials."
+    }
+
+    def "Delius unavailable doesn't prevent logging in as auth user"() {
+        given: 'I am on the Login page'
+        to LoginPage
+
+        when: "I login using valid Auth credentials"
+        loginAs AUTH_USER, 'password123456'
+
+        then: 'My credentials are accepted and I am shown the Home page'
+        at HomePage
+        principalName == 'Auth Only'
+    }
+
+    def "Delius unavailable doesn't prevent logging in as nomis user"() {
+        given: 'I am on the Login page'
+        to LoginPage
+
+        when: "I login using valid Nomis credentials"
+        loginAs ITAG_USER, 'password'
+
+        then: 'My credentials are accepted and I am shown the Home page'
+        at HomePage
+        principalName == 'Itag User'
+    }
+}

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/DeliusDownLoginSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/DeliusDownLoginSpecification.groovy
@@ -8,7 +8,7 @@ import static uk.gov.justice.digital.hmpps.oauth2server.integration.specs.model.
 import static uk.gov.justice.digital.hmpps.oauth2server.integration.specs.model.UserAccount.DELIUS_USER
 import static uk.gov.justice.digital.hmpps.oauth2server.integration.specs.model.UserAccount.ITAG_USER
 
-class DeliusDownLoginSepcification extends BrowserReportingSpec {
+class DeliusDownLoginSpecification extends BrowserReportingSpec {
 
     def "Delius unavailable shows in error"() {
         given: 'I am on the Login page'

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/InitialPasswordSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/InitialPasswordSpecification.groovy
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestTemplate
 import uk.gov.justice.digital.hmpps.oauth2server.api.specs.AuthUserSpecification.NewUser
 import uk.gov.justice.digital.hmpps.oauth2server.integration.specs.pages.*
 
-class InitialPasswordSpecification extends GebReportingSpec {
+class InitialPasswordSpecification extends DeliusIntegrationSpec {
 
     def "A licences user can be created and new password saved"() {
         given: 'A licence RO user has been created'

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/LoginSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/LoginSpecification.groovy
@@ -167,7 +167,8 @@ class LoginSpecification extends DeliusIntegrationSpec {
 
         then: 'My credentials are rejected and I am still on the Login page'
         at LoginErrorPage
-        errorText == 'Enter a valid username and password. You will be locked out if you enter the wrong details 3 times.'
+        errorText == "Enter a valid username and password. You will be locked out if you enter the wrong details 3 times." +
+                "\nDelius is experiencing issues. Please try later if you are attempting to login using your Delius credentials."
     }
 
     def "Log in with valid credentials"() {

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfigurationTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/AuthenticationManagerConfigurationTest.java
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.oauth2server.config;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import uk.gov.justice.digital.hmpps.oauth2server.resource.LoggingAccessDeniedHandler;
+import uk.gov.justice.digital.hmpps.oauth2server.resource.RedirectingLogoutSuccessHandler;
+import uk.gov.justice.digital.hmpps.oauth2server.security.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class AuthenticationManagerConfigurationTest {
+
+    @Mock private AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> nomisUserDetailsService;
+    @Mock private AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> authUserDetailsService;
+    @Mock private AuthenticationUserDetailsService<PreAuthenticatedAuthenticationToken> deliusUserDetailsService;
+    @Mock private LoggingAccessDeniedHandler accessDeniedHandler;
+    @Mock private RedirectingLogoutSuccessHandler logoutSuccessHandler;
+    @Mock private JwtAuthenticationSuccessHandler jwtAuthenticationSuccessHandler;
+    @Mock private JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter;
+    @Mock private String jwtCookieName;
+    @Mock private CookieRequestCache cookieRequestCache;
+    @Mock private AuthAuthenticationProvider authAuthenticationProvider;
+    @Mock private NomisAuthenticationProvider nomisAuthenticationProvider;
+    @Mock private DeliusAuthenticationProvider deliusAuthenticationProvider;
+    @Mock private UserStateAuthenticationFailureHandler userStateAuthenticationFailureHandle;
+
+    private AuthenticationManagerConfiguration authenticationManagerConfiguration;
+
+    @Before
+    public void setup() {
+        authenticationManagerConfiguration = new AuthenticationManagerConfiguration(nomisUserDetailsService, authUserDetailsService,
+                deliusUserDetailsService, accessDeniedHandler, logoutSuccessHandler, jwtAuthenticationSuccessHandler, jwtCookieAuthenticationFilter,
+                jwtCookieName, cookieRequestCache, authAuthenticationProvider, nomisAuthenticationProvider, deliusAuthenticationProvider,
+                userStateAuthenticationFailureHandle);
+    }
+
+
+    @Test
+    public void configure_deliusProviderIsLast() {
+        AuthenticationManagerBuilder authenticationManagerBuilder = mock(AuthenticationManagerBuilder.class);
+
+        authenticationManagerConfiguration.configure(authenticationManagerBuilder);
+
+        ArgumentCaptor<AuthenticationProvider> captor = ArgumentCaptor.forClass(LockingAuthenticationProvider.class);
+        verify(authenticationManagerBuilder, atLeastOnce()).authenticationProvider(captor.capture());
+        List<AuthenticationProvider> providers = captor.getAllValues().stream().filter(p -> !(p instanceof PreAuthenticatedAuthenticationProvider)).collect(Collectors.toList());
+        assertThat(providers.get(providers.size()-1)).isEqualTo(deliusAuthenticationProvider);
+    }
+
+}

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/delius/service/DeliusUserServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/delius/service/DeliusUserServiceTest.kt
@@ -8,11 +8,13 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
 import uk.gov.justice.digital.hmpps.oauth2server.config.DeliusRoleMappings
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.DeliusUserPersonDetails
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.UserDetails
 import uk.gov.justice.digital.hmpps.oauth2server.delius.model.UserRole
+import uk.gov.justice.digital.hmpps.oauth2server.security.DeliusAuthenticationServiceException
 
 @RunWith(MockitoJUnitRunner::class)
 class DeliusUserServiceTest {
@@ -117,6 +119,13 @@ class DeliusUserServiceTest {
             email = "somewhere@bob.com",
             enabled = true,
             roles = emptySet()))
+  }
+
+  @Test(expected = DeliusAuthenticationServiceException::class)
+  fun `getDeliusUserByUsername converts ResourceAccessException and rethrows`() {
+    whenever(restTemplate.getForObject<UserDetails>(anyString(), any(), anyString())).thenThrow(ResourceAccessException::class.java)
+
+    deliusService.getDeliusUserByUsername("any_username")
   }
 
   private fun createUserDetails(): UserDetails =

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserStateAuthenticationFailureHandlerTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/UserStateAuthenticationFailureHandlerTest.java
@@ -88,6 +88,13 @@ public class UserStateAuthenticationFailureHandlerTest {
     }
 
     @Test
+    public void onAuthenticationFailure_deliusDown() throws IOException {
+        handler.onAuthenticationFailure(request, response, new DeliusAuthenticationServiceException());
+
+        verify(redirectStrategy).sendRedirect(request, response, "/login?error=invalid&error=deliusdown");
+    }
+
+    @Test
     public void onAuthenticationFailure_other() throws IOException {
         handler.onAuthenticationFailure(request, response, new BadCredentialsException("msg"));
 


### PR DESCRIPTION
When logging in, if the attempt to authenticate the credentials against Delius fails because Delius is down, show a warning message on the login page indicating Delius is down.