### PR TITLE
DT-506: Prevent gsi email addresses in verify email

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/maintain/AuthUserService.kt
@@ -171,7 +171,7 @@ open class AuthUserService(private val userRepository: UserRepository,
     user.isEnabled = enabled
     // give user 7 days grace if last logged in more than x days ago
     if (user.lastLoggedIn.isBefore(LocalDateTime.now().minusDays(loginDaysTrigger.toLong()))) {
-      user.lastLoggedIn = LocalDateTime.now().minusDays(loginDaysTrigger - 7.toLong())
+      user.lastLoggedIn = LocalDateTime.now().minusDays(loginDaysTrigger - 7L)
     }
     userRepository.save(user)
     telemetryClient.trackEvent("AuthUserChangeEnabled",

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/resource/ResetPasswordController.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/resource/ResetPasswordController.java
@@ -69,7 +69,7 @@ public class ResetPasswordController extends AbstractPasswordController {
 
         if (StringUtils.contains(usernameOrEmail, "@")) {
             try {
-                verifyEmailService.validateEmailAddress(EmailHelper.format(usernameOrEmail));
+                verifyEmailService.validateEmailAddressExcludingGsi(EmailHelper.format(usernameOrEmail));
             } catch (final VerifyEmailException e) {
                 log.info("Validation failed for reset password email address due to {}", e.getReason());
                 telemetryClient.trackEvent("VerifyEmailRequestFailure", Map.of("email", usernameOrEmail, "reason", "email." + e.getReason()), null);

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/verify/VerifyEmailService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/verify/VerifyEmailService.java
@@ -95,6 +95,11 @@ public class VerifyEmailService {
     }
 
     public void validateEmailAddress(final String email) throws VerifyEmailException {
+        validateEmailAddressExcludingGsi(email);
+        if (email.matches(".*@.*\\.gsi\\.gov\\.uk")) throw new VerifyEmailException("gsi");
+    }
+
+    public void validateEmailAddressExcludingGsi(final String email) throws VerifyEmailException {
         if (StringUtils.isBlank(email)) {
             throw new VerifyEmailException("blank");
         }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -35,6 +35,7 @@ verifyemail.together=Enter an email address that does not have @ and a full stop
 verifyemail.white=Remove any blank spaces from your email address
 verifyemail.characters=Enter an email address that only has the following characters: 0-9A-Za-z@.'_-+
 verifyemail.domain=Enter your work email address
+verifyemail.gsi=All gsi.gov.uk have now been migrated to a justice.gov.uk domain.  Enter your justice.gov.uk address instead.
 verifyemail.other=An error occurred during sending the verification email. Please try again.
 
 resetpassword.missing=Enter your username or email address
@@ -45,6 +46,7 @@ resetpassword.email.together=Enter an email address that does not have @ and a f
 resetpassword.email.white=Remove any blank spaces from your email address
 resetpassword.email.characters=Enter an email address that only has the following characters: 0-9A-Za-z@.'_-+
 resetpassword.email.domain=Enter your work email address
+resetpassword.email.gsi=All gsi.gov.uk have now been migrated to a justice.gov.uk domain.  Enter your justice.gov.uk address instead.
 resetpassword.other=Sorry, we could not send the password reset email. Please try again.
 resetpassword.throttled=There are too many requests for password reset at present. Please wait a minute and try again.
 resetpassword.invalid=This link is invalid. Please enter your username or email address and try again.

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/ResetPasswordSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/ResetPasswordSpecification.groovy
@@ -37,6 +37,19 @@ class ResetPasswordSpecification extends DeliusIntegrationSpec {
         usernameInput == 'joe@bloggs.com'
     }
 
+    def "A user can enter their gsi email address to reset their password"() {
+        given: 'I would like to reset my password'
+        to LoginPage
+        resetPassword()
+
+        when: 'The Reset Password page is displayed'
+        at ResetPasswordPage
+        resetPasswordAs 'reset_test@hmps.gsi.gov.uk'
+
+        then: 'The Reset Password sent page is displayed'
+        at ResetPasswordSentPage
+    }
+
     def "A user can enter an email address to reset their password"() {
         given: 'I would like to reset my password'
         to LoginPage

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/VerifyEmailSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/VerifyEmailSpecification.groovy
@@ -22,6 +22,20 @@ class VerifyEmailSpecification extends GebReportingSpec {
         at HomePage
     }
 
+    def "A user is not allowed to verify a gsi email address"() {
+        given: 'I login with a non verified email user'
+        to LoginPage
+        loginAs AUTH_NO_EMAIL, 'password123456'
+
+        when: 'The Verify Email page is displayed'
+        at VerifyEmailPage
+        verifyEmailAs 'dm_user@hmps.gsi.gov.uk'
+
+        then:
+        at VerifyEmailErrorPage
+        errorDetail.startsWith('All gsi.gov.uk have now been migrated to a justice.gov.uk domain. Enter your justice.gov.uk address instead.')
+    }
+
     def "A user can verify a previously chosen email"() {
         given: 'I login with a non verified email user'
         to LoginPage
@@ -132,7 +146,7 @@ class VerifyEmailSpecification extends GebReportingSpec {
         browser.go verifyLink
 
         then:
-        at VerifyEmailErrorPage
+        at VerifyEmailConfirmErrorPage
         errorDetail.startsWith('This link is invalid')
     }
 }

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/pages/VerifyEmailConfirmErrorPage.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/pages/VerifyEmailConfirmErrorPage.groovy
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.oauth2server.integration.specs.pages
+
+class VerifyEmailConfirmErrorPage extends VerifyEmailConfirmPage {
+
+  static at = {
+    title == 'Error: HMPPS Digital Services - Verify Email Confirmation'
+  }
+
+  static content = {
+    errorDetail { $('#error-detail').text() }
+  }
+}

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/pages/VerifyEmailErrorPage.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/integration/specs/pages/VerifyEmailErrorPage.groovy
@@ -1,13 +1,9 @@
 package uk.gov.justice.digital.hmpps.oauth2server.integration.specs.pages
 
-import geb.Page
-
-class VerifyEmailErrorPage extends Page {
-
-    static url = '/auth/verify-email-confirm'
+class VerifyEmailErrorPage extends VerifyEmailPage {
 
     static at = {
-        title == 'Error: HMPPS Digital Services - Verify Email Confirmation'
+        title == 'Error: HMPPS Digital Services - Verify Email'
     }
 
     static content = {

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/resource/ResetPasswordControllerTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/resource/ResetPasswordControllerTest.kt
@@ -5,7 +5,7 @@ import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito
+import org.mockito.Mockito.doThrow
 import uk.gov.justice.digital.hmpps.oauth2server.auth.model.User
 import uk.gov.justice.digital.hmpps.oauth2server.auth.model.UserToken
 import uk.gov.justice.digital.hmpps.oauth2server.nomis.model.AccountDetail
@@ -122,7 +122,7 @@ class ResetPasswordControllerTest {
   @Test
   @Throws(NotificationClientRuntimeException::class, VerifyEmailException::class)
   fun resetPasswordRequest_emailfailed() {
-    Mockito.doThrow(VerifyEmailException("reason")).whenever(verifyEmailService).validateEmailAddress(anyString())
+    doThrow(VerifyEmailException("reason")).whenever(verifyEmailService).validateEmailAddressExcludingGsi(anyString())
     val modelAndView = controller.resetPasswordRequest("user@somewhere", request)
     assertThat(modelAndView.viewName).isEqualTo("resetPassword")
     assertThat(modelAndView.model).containsOnly(entry("error", "email.reason"), entry("usernameOrEmail", "user@somewhere"))
@@ -131,10 +131,10 @@ class ResetPasswordControllerTest {
   @Test
   @Throws(NotificationClientRuntimeException::class, VerifyEmailException::class)
   fun resetPasswordRequest_emailhelperapostrophe() {
-    Mockito.doThrow(VerifyEmailException("reason")).whenever(verifyEmailService).validateEmailAddress(anyString())
+    doThrow(VerifyEmailException("reason")).whenever(verifyEmailService).validateEmailAddressExcludingGsi(anyString())
     val modelAndView = controller.resetPasswordRequest("us.o’er@someWHERE.com   ", request)
     assertThat(modelAndView.viewName).isEqualTo("resetPassword")
-    verify(verifyEmailService).validateEmailAddress("us.o'er@somewhere.com")
+    verify(verifyEmailService).validateEmailAddressExcludingGsi("us.o'er@somewhere.com")
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/VerifyEmailServiceTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/verify/VerifyEmailServiceTest.kt
@@ -124,6 +124,15 @@ class VerifyEmailServiceTest {
   }
 
   @Test
+  @Throws(NotificationClientException::class, VerifyEmailException::class)
+  fun requestVerification_gsiEmail() {
+    val user = Optional.of(User.of("someuser"))
+    whenever(userRepository.findByUsername(anyString())).thenReturn(user)
+    whenever(referenceCodesService.isValidEmailDomain(anyString())).thenReturn(true)
+    verifyEmailFailure("some.u'ser@SOMEwhe.gsi.gov.uk", "gsi")
+  }
+
+  @Test
   fun verifyEmail_NoAtSign() {
     verifyEmailFailure("a", "format")
   }


### PR DESCRIPTION
We haven't migrated all the gsi.gov.uk email addresses of users yet, so there will be some people who will need to reset their password with one of those.  However we can prevent more people verifying with a gsi.gov.uk email address and prevent in amend / create user too.