### PR TITLE
WIP DT-635 Attempt to find the user even for proxy-users.

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/JWTTokenEnhancer.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/JWTTokenEnhancer.java
@@ -60,10 +60,9 @@ public class JWTTokenEnhancer implements TokenEnhancer {
         final var request = authentication.getOAuth2Request();
 
         final var requestParams = request.getRequestParameters();
-        final var skipUserCheck = request.getScope().contains("proxy-user");
 
         // Non-blank user_id_type and user_id to check - delegate to external identifier auth component
-        final var userDetails = externalIdAuthenticationHelper.getUserDetails(requestParams, skipUserCheck);
+        final var userDetails = externalIdAuthenticationHelper.getUserDetails(requestParams);
 
         if (userDetails != null) {
             additionalInfo.put(ADD_INFO_AUTH_SOURCE, userDetails.getAuthSource());

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelper.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelper.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -21,12 +20,9 @@ public class ExternalIdAuthenticationHelper {
 
     private final UserService userService;
 
-    public UserPersonDetails getUserDetails(final Map<String, String> requestParameters, final boolean skipUserCheck) {
+    public UserPersonDetails getUserDetails(final Map<String, String> requestParameters) {
         if (requestParameters.containsKey(REQUEST_PARAM_USER_NAME)) {
             final var username = requestParameters.get(REQUEST_PARAM_USER_NAME);
-            if (skipUserCheck) {
-                return new UserDetailsImpl(username, null, List.of(), "none", null);
-            }
             return loadByUsername(username);
         }
         return null;

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/LoggingTokenServicesTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/LoggingTokenServicesTest.kt
@@ -45,14 +45,14 @@ internal class LoggingTokenServicesTest {
 
   @Test
   fun createAccessToken_ClientOnly() {
-    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap(), eq(false))).thenReturn(USER_DETAILS)
+    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap())).thenReturn(USER_DETAILS)
     loggingTokenServices.createAccessToken(OAuth2Authentication(OAUTH_2_REQUEST, null))
     verify(telemetryClient, never()).trackEvent(any(), anyMap(), isNull())
   }
 
   @Test
   fun createAccessToken_ClientOnlyProxyUser() {
-    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap(), eq(true))).thenReturn(UNCHECKED_USER_DETAILS)
+    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap())).thenReturn(UNCHECKED_USER_DETAILS)
     loggingTokenServices.createAccessToken(OAuth2Authentication(OAUTH_2_SCOPE_REQUEST, null))
     verify(telemetryClient, never()).trackEvent(any(), anyMap(), isNull())
   }

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelperTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelperTest.kt
@@ -17,13 +17,13 @@ class ExternalIdAuthenticationHelperTest {
   @Test
   fun userDetails_notFound() {
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.empty())
-    assertThatThrownBy { helper.getUserDetails(mapOf("username" to "bobuser"), false) }
+    assertThatThrownBy { helper.getUserDetails(mapOf("username" to "bobuser")) }
         .isInstanceOf(OAuth2AccessDeniedException::class.java).hasMessage("No user found matching username.")
   }
 
   @Test
   fun userDetails_found() {
-    val details = helper.getUserDetails(mapOf("username" to "bobuser"), true)
+    val details = helper.getUserDetails(mapOf("username" to "bobuser"))
     assertThat(details).isNotNull()
   }
 }


### PR DESCRIPTION
If we know that the token has been issued to a known user then any
consuming service can decide how much to trust that user.  For example
we might want to let Auth users perform certain updates that we'd reject
for an unknown proxy-user.