### PR TITLE
Dt 635 unknown proxy user

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/JWTTokenEnhancer.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/config/JWTTokenEnhancer.java
@@ -60,10 +60,9 @@ public class JWTTokenEnhancer implements TokenEnhancer {
         final var request = authentication.getOAuth2Request();
 
         final var requestParams = request.getRequestParameters();
-        final var skipUserCheck = request.getScope().contains("proxy-user");
 
         // Non-blank user_id_type and user_id to check - delegate to external identifier auth component
-        final var userDetails = externalIdAuthenticationHelper.getUserDetails(requestParams, skipUserCheck);
+        final var userDetails = externalIdAuthenticationHelper.getUserDetails(requestParams);
 
         if (userDetails != null) {
             additionalInfo.put(ADD_INFO_AUTH_SOURCE, userDetails.getAuthSource());

--- a/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelper.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelper.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -21,12 +20,9 @@ public class ExternalIdAuthenticationHelper {
 
     private final UserService userService;
 
-    public UserPersonDetails getUserDetails(final Map<String, String> requestParameters, final boolean skipUserCheck) {
+    public UserPersonDetails getUserDetails(final Map<String, String> requestParameters) {
         if (requestParameters.containsKey(REQUEST_PARAM_USER_NAME)) {
             final var username = requestParameters.get(REQUEST_PARAM_USER_NAME);
-            if (skipUserCheck) {
-                return new UserDetailsImpl(username, null, List.of(), "none", null);
-            }
             return loadByUsername(username);
         }
         return null;

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/api/specs/OauthSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/oauth2server/api/specs/OauthSpecification.groovy
@@ -102,10 +102,22 @@ class OauthSpecification extends TestSpecification {
         token.additionalInformation.auth_source == 'auth'
     }
 
-    def "Client Credentials Login access token for non auth or nomis user"() {
+    def "Client Credentials Login failure token for unknown user"() {
 
         given:
         def oauthRestTemplate = getOauthClientGrant("community-api-client", "clientsecret", "username=NPSUser")
+
+        when:
+        oauthRestTemplate.getAccessToken()
+
+        then:
+        OAuth2AccessDeniedException ex = thrown()
+    }
+
+    def "Client Credentials Login access token for proxy user with no username"() {
+
+        given:
+        def oauthRestTemplate = getOauthClientGrant("community-api-client", "clientsecret")
 
         when:
         def token = oauthRestTemplate.getAccessToken()

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/LoggingTokenServicesTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/config/LoggingTokenServicesTest.kt
@@ -45,14 +45,14 @@ internal class LoggingTokenServicesTest {
 
   @Test
   fun createAccessToken_ClientOnly() {
-    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap(), eq(false))).thenReturn(USER_DETAILS)
+    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap())).thenReturn(USER_DETAILS)
     loggingTokenServices.createAccessToken(OAuth2Authentication(OAUTH_2_REQUEST, null))
     verify(telemetryClient, never()).trackEvent(any(), anyMap(), isNull())
   }
 
   @Test
   fun createAccessToken_ClientOnlyProxyUser() {
-    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap(), eq(true))).thenReturn(UNCHECKED_USER_DETAILS)
+    whenever(externalIdAuthenticationHelper.getUserDetails(anyMap())).thenReturn(UNCHECKED_USER_DETAILS)
     loggingTokenServices.createAccessToken(OAuth2Authentication(OAUTH_2_SCOPE_REQUEST, null))
     verify(telemetryClient, never()).trackEvent(any(), anyMap(), isNull())
   }

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelperTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelperTest.kt
@@ -17,13 +17,13 @@ class ExternalIdAuthenticationHelperTest {
   @Test
   fun userDetails_notFound() {
     whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.empty())
-    assertThatThrownBy { helper.getUserDetails(mapOf("username" to "bobuser"), false) }
+    assertThatThrownBy { helper.getUserDetails(mapOf("username" to "bobuser")) }
         .isInstanceOf(OAuth2AccessDeniedException::class.java).hasMessage("No user found matching username.")
   }
 
   @Test
   fun userDetails_found() {
-    val details = helper.getUserDetails(mapOf("username" to "bobuser"), true)
+    val details = helper.getUserDetails(mapOf("username" to "bobuser"))
     assertThat(details).isNotNull()
   }
 }

--- a/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelperTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/oauth2server/security/ExternalIdAuthenticationHelperTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException
+import uk.gov.justice.digital.hmpps.oauth2server.delius.model.DeliusUserPersonDetails
 import java.util.*
 
 @Suppress("DEPRECATION")
@@ -23,7 +24,19 @@ class ExternalIdAuthenticationHelperTest {
 
   @Test
   fun userDetails_found() {
+    whenever(userService.findMasterUserPersonDetails(anyString())).thenReturn(Optional.of(aDeliusUser()))
     val details = helper.getUserDetails(mapOf("username" to "bobuser"))
     assertThat(details).isNotNull()
+  }
+
+  private fun aDeliusUser(): DeliusUserPersonDetails {
+    return DeliusUserPersonDetails(
+        username = "derrick.boom",
+        userId = "dboom",
+        firstName = "Derrick",
+        surname = "Boom",
+        email = "derrick@boom.com",
+        enabled = true
+    )
   }
 }


### PR DESCRIPTION
Client credential requests for an unknown user are now rejected as we cannot determine the authentication source.
Requests for a missing user will continue to return source "none",